### PR TITLE
Fix Serbian Cyrillic assist being vetoed by words shared with Serbian

### DIFF
--- a/app/core/validator.py
+++ b/app/core/validator.py
@@ -121,12 +121,15 @@ def detect_language_heuristics(text: str, expected_language: Optional[str] = Non
         # Only assist to 'sr' when POSITIVE Serbian diagnostic evidence is present (diagnostic letters ђ, ћ
         # or distinctive grammatical words је, није, ово, шта, данас, пре, сви, овај, dobrodošli/хвала/молимо)
         # AND positive Macedonian diagnostic evidence is ABSENT.
+        # Note: the Macedonian marker list must contain only words that are NOT also
+        # standard Serbian. Words like ова / овој / нема / треба / во occur naturally in
+        # Serbian and would otherwise veto the assist on genuine Serbian Cyrillic text.
         # Neutral or ambiguous Cyrillic without positive Serbian evidence stays 'mk' / unchanged.
         if expected_norm == "sr" and detected_code == "mk":
             has_cyrillic = bool(re.search(r'[\u0400-\u04FF]', cleaned))
             if has_cyrillic:
                 has_sr_evidence = bool(re.search(r'[\u0402\u0452\u040B\u045B]|\b(је|није|ово|шта|данас|пре|сви|овај|овог|овом|добродошли|хвала|молимо)\b', cleaned, re.IGNORECASE))
-                has_mk_evidence = bool(re.search(r'[\u0403\u0453\u0405\u0455\u040C\u045C]|\b(ова|оваа|овој|овие|денес|зошто|нема|сака|треба|веќе|тука|многу|додека|во)\b', cleaned, re.IGNORECASE))
+                has_mk_evidence = bool(re.search(r'[\u0403\u0453\u0405\u0455\u040C\u045C]|\b(оваа|овие|денес|зошто|сака|веќе|тука|многу|додека)\b', cleaned, re.IGNORECASE))
                 if has_sr_evidence and not has_mk_evidence:
                     detected_code = "sr"
 

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -135,6 +135,28 @@ def test_short_english_rescue_unregistered_detector_noise():
     assert res_af["confidence"] >= 0.95
 
 
+def test_serbian_cyrillic_not_vetoed_by_shared_bcs_words():
+    """Issue #5: words that exist in BOTH Serbian and Macedonian must not veto the Serbian assist.
+
+    'нема', 'треба', 'овој' and 'ова' are ordinary Serbian. Previously any one of them
+    was treated as positive Macedonian evidence, so genuine Serbian Cyrillic containing
+    conclusive markers (ђ, ћ, није, шта) was still rejected as 'mk'.
+    """
+    shared_word_samples = [
+        # 'нема' - identical in Serbian and Macedonian
+        "Није било лако, али нема шта да се ради. Ђорђе је рекао да ће доћи сутра увече.",
+        # 'треба' - identical in Serbian and Macedonian
+        "Шта треба да урадимо сада? Ђаво је однео шалу, али ово није крај приче.",
+        # 'овој' - Serbian feminine locative of 'овај'
+        "У овој кући је увек било топло. Није важно шта други мисле о нама и о ђацима.",
+        # 'ова' - ordinary Serbian plural
+        "Ова деца су највише уживала. Шта је било, није важно, ђак је ћутао цело вече.",
+    ]
+    for text in shared_word_samples:
+        res = detect_language_heuristics(text, expected_language="sr")
+        assert res["lang"] == "sr", f"Serbian text falsely vetoed as {res['lang']}: {text[:40]}"
+
+
 def test_macedonian_vs_serbian_cyrillic_differentiation():
     """Genuine Macedonian with expected_language='sr' must not be falsely converted to exact Serbian."""
     # Standard Macedonian sample with common markers


### PR DESCRIPTION
Fixes #5.

The Serbian Cyrillic assist requires positive Serbian evidence **and** absence of Macedonian evidence. The Macedonian list contained five words that are also perfectly ordinary Serbian, so a single one of them vetoed the assist even when the text carried conclusive Serbian markers:

| Word | Why it's ambiguous |
|---|---|
| `нема` | identical in Serbian and Macedonian |
| `треба` | identical in Serbian and Macedonian |
| `овој` | Serbian feminine locative of *овај* |
| `ова` | ordinary Serbian plural |
| `во` | Macedonian "in", but appears in Serbian text often enough to be risky as a veto |

This drops those five and keeps only genuinely Macedonian-specific markers (`оваа`, `овие`, `денес`, `зошто`, `сака`, `веќе`, `тука`, `многу`, `додека`) plus the diagnostic letters `ѓ`, `ќ`, `ѕ`.

## Results

Measured on 500 real `.sr.srt` files from my library (mixed Latin and Cyrillic, mostly titlovi):

| | before | after |
|---|---|---|
| Cyrillic files passing all three stratified sections | 1/7 | **7/7** |
| Overall QA gate GREEN | 98.0% | **99.2%** |

The four remaining failures are genuinely mislabelled source files — one Greek, one Slovenian, one Serbian file whose end credits are English song lyrics, and one whose opening section is a cast-and-credits block of proper names. Babel is right to reject the first three.

## Tests

- Adds `test_serbian_cyrillic_not_vetoed_by_shared_bcs_words`, covering all four shared words. It fails on `main` (`- sr / + mk`) and passes with this change.
- `test_macedonian_vs_serbian_cyrillic_differentiation` still passes unchanged — the real Macedonian samples are matched by the retained markers, so genuine Macedonian is still correctly refused.
- Full suite: **640 passed** (639 on `main` + 1 new), no regressions.

## Note on the diacritic test

Worth considering separately: the letter test alone — `ђ`/`ћ` present and `ѓ`/`ќ`/`ѕ` absent — also scored 7/7 on my sample and doesn't depend on vocabulary at all. Macedonian doesn't use `ђ`/`ћ` and Serbian doesn't use `ѓ`/`ќ`/`ѕ`, so letters may be the more durable primary signal with words as a tiebreaker. I kept this PR to the minimal fix rather than restructuring your logic.

Also unrelated to this change, but you may want to know: `pip install -r requirements.txt` currently fails because `pysubs2==1.9.0` doesn't exist on PyPI (latest is 1.8.1). I had to relax that pin to run the suite locally.
