### PR TITLE
Fix Anthropic provider 400: convert internal schemas to real JSON Schema

### DIFF
--- a/app/services/translator.py
+++ b/app/services/translator.py
@@ -1578,7 +1578,24 @@ class SubtitleTranslator:
         get_provider_spec(p)  # raises ValueError("Unsupported AI provider: ...") for unknown providers
         return context_from_settings(p).model
 
-    def _convert_to_openai_json_schema(self, schema: dict) -> dict:
+    def _convert_to_strict_json_schema(self, schema: dict, force_all_required: bool = False) -> dict:
+        """
+        Convert an internally-authored schema into strict JSON Schema.
+
+        Schemas in this module are authored in Google GenAI's convention, which
+        spells types in uppercase ("OBJECT", "STRING"). That is accepted by
+        google-genai's `response_schema`, but every other provider expects real
+        JSON Schema, where types are lowercase. This normalizes:
+
+          * `type` lowercased recursively (objects, arrays, nested properties)
+          * `additionalProperties: false` on every object (required by both
+            OpenAI strict mode and Anthropic's `output_config.format`)
+
+        `force_all_required` additionally promotes every property into
+        `required`. OpenAI strict mode mandates that; Anthropic does not, and
+        enabling it there would silently make genuinely optional fields
+        (e.g. the `reason`/`details` audit fields) mandatory. So it is opt-in.
+        """
         if not isinstance(schema, dict):
             return schema
         res = {}
@@ -1586,19 +1603,26 @@ class SubtitleTranslator:
             if k == "type" and isinstance(v, str):
                 res["type"] = v.lower()
             elif k == "properties" and isinstance(v, dict):
-                res["properties"] = {pk: self._convert_to_openai_json_schema(pv) for pk, pv in v.items()}
+                res["properties"] = {
+                    pk: self._convert_to_strict_json_schema(pv, force_all_required)
+                    for pk, pv in v.items()
+                }
             elif k == "items" and isinstance(v, dict):
-                res["items"] = self._convert_to_openai_json_schema(v)
+                res["items"] = self._convert_to_strict_json_schema(v, force_all_required)
             else:
                 res[k] = v
         if res.get("type") == "object":
             if "additionalProperties" not in res:
                 res["additionalProperties"] = False
-            if "properties" in res:
+            if force_all_required and "properties" in res:
                 res["required"] = list(res.get("required", [])) + [
                     pk for pk in res["properties"].keys() if pk not in res.get("required", [])
                 ]
         return res
+
+    def _convert_to_openai_json_schema(self, schema: dict) -> dict:
+        """Strict JSON Schema for OpenAI-compatible providers (all properties required)."""
+        return self._convert_to_strict_json_schema(schema, force_all_required=True)
 
     async def _dispatch_llm_completion(
         self,
@@ -1735,6 +1759,16 @@ class SubtitleTranslator:
             # Fallback for older models: inject JSON schema into system prompt
             _use_native_output_config = bool(schema and caps.native_output_config)
 
+            # Schemas are authored in Google GenAI's uppercase convention, which is
+            # not valid JSON Schema. Anthropic rejects it outright with a 400
+            # ("Invalid JSON Schema in output format"), so normalize before use.
+            # force_all_required stays off: Anthropic only requires
+            # additionalProperties:false, and promoting every property would make
+            # deliberately optional fields mandatory.
+            _anthropic_schema = (
+                self._convert_to_strict_json_schema(schema) if schema else None
+            )
+
             _system_prompt = system_prompt
             if schema and not _use_native_output_config:
                 # Strict JSON fallback: describe schema in system prompt
@@ -1742,7 +1776,7 @@ class SubtitleTranslator:
                 _system_prompt = (
                     f"{system_prompt}\n\n"
                     "IMPORTANT: You MUST respond with ONLY valid JSON matching this schema:\n"
-                    f"{_json.dumps(schema, indent=2)}\n"
+                    f"{_json.dumps(_anthropic_schema, indent=2)}\n"
                     "No markdown, no explanation, no preamble. Raw JSON only."
                 )
 
@@ -1760,7 +1794,7 @@ class SubtitleTranslator:
                 payload["output_config"] = {
                     "format": {
                         "type": "json_schema",
-                        "schema": schema,
+                        "schema": _anthropic_schema,
                     }
                 }
             async with httpx.AsyncClient(timeout=60.0) as client:

--- a/tests/test_anthropic_structured_output.py
+++ b/tests/test_anthropic_structured_output.py
@@ -66,9 +66,159 @@ async def test_anthropic_native_output_config_in_payload_for_supported_model():
         f"output_config missing for claude-sonnet-5+schema. Keys: {list(payload.keys())}"
     )
     assert payload["output_config"]["format"]["type"] == "json_schema"
-    assert payload["output_config"]["format"]["schema"] == SCHEMA
+    # The schema must be normalized to real JSON Schema, NOT forwarded verbatim.
+    # SCHEMA is authored in Google GenAI's uppercase convention; Anthropic rejects
+    # that with 400 "Invalid JSON Schema in output format".
+    sent = payload["output_config"]["format"]["schema"]
+    assert sent == {
+        "type": "object",
+        "properties": {
+            "translations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"id": {"type": "integer"}, "text": {"type": "string"}},
+                    "required": ["id", "text"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+        "required": ["translations"],
+        "additionalProperties": False,
+    }
     assert "temperature" not in payload, "claude-sonnet-5 does not support temperature"
     assert payload["model"] == "claude-sonnet-5"
+
+
+def _iter_types(node):
+    """Yield every 'type' string value in a nested schema."""
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == "type" and isinstance(v, str):
+                yield v
+            else:
+                yield from _iter_types(v)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_types(item)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_payload_never_contains_uppercase_types():
+    """Regression: no uppercase type name may survive into the Anthropic payload.
+
+    Anthropic returns 400 for any schema still using the Google GenAI convention.
+    """
+    from app.services.translator import SubtitleTranslator
+    translator = SubtitleTranslator()
+    captured_payloads = []
+
+    async def fake_post(url, **kwargs):
+        captured_payloads.append(kwargs.get("json", {}))
+        return _make_mock_response(text='{"translations": []}')
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock(side_effect=fake_post)
+
+    with patch("app.services.translator.get_setting", side_effect=lambda k, d=None: {
+             "anthropic_api_key": "sk-ant-test", "anthropic_model": "claude-sonnet-5"
+         }.get(k, d)), \
+         patch("httpx.AsyncClient", return_value=mock_client):
+
+        await translator._dispatch_llm_completion(
+            provider="anthropic",
+            model_name="claude-sonnet-5",
+            system_prompt="You are a translator.",
+            user_prompt="Translate: Hello",
+            schema=SCHEMA,
+            temperature=0.1,
+        )
+
+    sent = captured_payloads[0]["output_config"]["format"]["schema"]
+    bad = [t for t in _iter_types(sent) if t != t.lower()]
+    assert not bad, f"uppercase JSON types leaked into Anthropic payload: {bad}"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_preserves_optional_fields_in_required():
+    """Anthropic must not have optional properties promoted into `required`.
+
+    Anthropic only requires additionalProperties:false. Several audit schemas
+    deliberately leave fields such as `details` optional; forcing them required
+    would change model behavior.
+    """
+    from app.services.translator import SubtitleTranslator
+    translator = SubtitleTranslator()
+    captured_payloads = []
+
+    partial_required = {
+        "type": "OBJECT",
+        "properties": {
+            "verdict": {"type": "STRING"},
+            "confidence": {"type": "STRING"},
+            "details": {"type": "STRING"},
+        },
+        "required": ["verdict", "confidence"],
+    }
+
+    async def fake_post(url, **kwargs):
+        captured_payloads.append(kwargs.get("json", {}))
+        return _make_mock_response(text='{"verdict": "ok", "confidence": "high"}')
+
+    mock_client = MagicMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    mock_client.post = AsyncMock(side_effect=fake_post)
+
+    with patch("app.services.translator.get_setting", side_effect=lambda k, d=None: {
+             "anthropic_api_key": "sk-ant-test", "anthropic_model": "claude-sonnet-5"
+         }.get(k, d)), \
+         patch("httpx.AsyncClient", return_value=mock_client):
+
+        await translator._dispatch_llm_completion(
+            provider="anthropic",
+            model_name="claude-sonnet-5",
+            system_prompt="Audit.",
+            user_prompt="Audit this.",
+            schema=partial_required,
+            temperature=None,
+        )
+
+    sent = captured_payloads[0]["output_config"]["format"]["schema"]
+    assert sent["required"] == ["verdict", "confidence"], (
+        f"optional field was promoted to required: {sent['required']}"
+    )
+    assert sent["additionalProperties"] is False
+
+
+def test_strict_schema_conversion_variants():
+    """The shared converter: lowercase + additionalProperties always; required opt-in."""
+    from app.services.translator import SubtitleTranslator
+    translator = SubtitleTranslator()
+
+    src = {
+        "type": "OBJECT",
+        "properties": {"a": {"type": "STRING"}, "b": {"type": "INTEGER"}},
+        "required": ["a"],
+    }
+
+    # Anthropic flavor: preserve authored `required`
+    anthropic = translator._convert_to_strict_json_schema(src)
+    assert anthropic["type"] == "object"
+    assert anthropic["properties"]["b"]["type"] == "integer"
+    assert anthropic["additionalProperties"] is False
+    assert anthropic["required"] == ["a"]
+
+    # OpenAI flavor: strict mode promotes every property
+    openai = translator._convert_to_openai_json_schema(src)
+    assert openai["additionalProperties"] is False
+    assert sorted(openai["required"]) == ["a", "b"]
+
+    # Input must not be mutated
+    assert src["type"] == "OBJECT"
+    assert src["required"] == ["a"]
 
 
 @pytest.mark.asyncio
@@ -108,6 +258,12 @@ async def test_anthropic_fallback_json_prompt_for_unsupported_model():
         "Schema properties must be injected into system prompt for fallback models"
     )
     assert "json" in payload["system"].lower(), "system prompt must mention JSON for fallback"
+    # The inlined schema should also be real JSON Schema — describing types as
+    # "OBJECT"/"STRING" to the model is inconsistent with the JSON it must emit.
+    assert '"OBJECT"' not in payload["system"] and '"STRING"' not in payload["system"], (
+        "uppercase Google GenAI types leaked into the fallback system prompt"
+    )
+    assert '"object"' in payload["system"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #12.

## Problem

Every request to the Anthropic provider fails with `400 Bad Request`, so the provider is completely unusable:

```
output_config.format.schema: Invalid JSON Schema in output format:
{'type': 'OBJECT', 'properties': {...}} is not valid under any of the given schemas
```

Schemas in `translator.py` are authored in Google GenAI's convention, which spells types in uppercase (`"OBJECT"`, `"ARRAY"`, `"INTEGER"`, `"STRING"`). `google-genai` accepts that in `response_schema`; nothing else does. The OpenAI-family branch already normalized via `_convert_to_openai_json_schema()`, but the Anthropic branch passed the schema through untouched.

**This is not limited to translation.** There are 67 uppercase type declarations across 13 schemas in `translator.py`, and all of them reach Anthropic through `_dispatch_llm_completion`:

`build_translation_output_schema` · `classify_and_recover_identical` · `audit_cue_alignment_batch` · `audit_batch_semantic_integrity` · `verify_alphabetic_invariants_batch` · `classify_sdh_segments` · `first_pass_micro_repair_batch` · `bulk_contextual_recovery` · `bulk_strict_recovery` · `repair_alignment_region` · `audit_cue_alignment_window` · `confirm_batch_semantic_integrity` · `escalate_single_line`

It also affects **every current Claude model**, since `caps.native_output_config` is `True` for sonnet-5, opus-5, fable-5, haiku-4-5, sonnet-4-5 and opus-4-1. Only `claude-3-*` / `claude-2` escape the 400, because they take the prompt-injection fallback — which was inlining the same uppercase schema into the system prompt, telling the model to emit `"STRING"`-typed fields.

## What I verified against the live API

I probed `api.anthropic.com` directly to establish the exact contract rather than assume it:

| Schema sent | Result |
|---|---|
| Uppercase types (current `main`) | **400** — invalid JSON Schema |
| Lowercase, no `additionalProperties` | **400** — `For 'object' type, 'additionalProperties' must be explicitly set to false` |
| Lowercase + `additionalProperties: false`, **partial** `required` | **200** |
| Lowercase + `additionalProperties: false` on nested objects, partial `required` | **200** |

Two conclusions drive the shape of this fix:

1. Anthropic requires `additionalProperties: false` on **every** object, nested ones included.
2. Anthropic does **not** require every property to be listed in `required`.

Point 2 is why I did not simply call the existing `_convert_to_openai_json_schema()` here. OpenAI strict mode mandates that every property be promoted into `required`, and several schemas deliberately leave fields optional — `reason` in `classify_and_recover_identical`, `details` in the alignment auditors. Reusing the OpenAI converter would have produced a valid request while silently forcing the model to populate fields the prompt treats as optional.

## Change

Split the existing converter into a shared core with an opt-in flag:

- `_convert_to_strict_json_schema(schema, force_all_required=False)` — recursive lowercasing plus `additionalProperties: false`.
- `_convert_to_openai_json_schema(schema)` — thin wrapper passing `force_all_required=True`, so OpenAI/OpenRouter/DeepSeek/custom behavior is byte-for-byte unchanged.

The Anthropic branch now converts once and uses the result for both the native `output_config.format.schema` and the older-model system-prompt fallback.

Gemini is untouched and still receives the uppercase schema its SDK expects.

## Tests

`tests/test_anthropic_structured_output.py` contained:

```python
assert payload["output_config"]["format"]["schema"] == SCHEMA
```

That asserted the raw uppercase schema was forwarded verbatim — encoding the bug as the expected contract. Because the suite mocks the HTTP transport, it never learned the API rejects it, which is how this passed CI while the provider was 100% broken. I updated it to assert the normalized schema, and added:

- `test_anthropic_payload_never_contains_uppercase_types` — walks the serialized payload and fails on any surviving uppercase type, so this can't regress via a new schema.
- `test_anthropic_preserves_optional_fields_in_required` — guards point 2 above.
- `test_strict_schema_conversion_variants` — both converter flavors, plus non-mutation of the input.
- An assertion on the fallback path that no uppercase types reach the system prompt.

Beyond the mocked tests I also ran the real converter output for three actual schemas (translation, plus the two with optional fields) against the live Anthropic API — all three return 200 with correctly-shaped JSON.

Full suite: `pytest -q` — **1246 passed, 0 failed**.

## Not included

The 400 response body is discarded by `resp.raise_for_status()` (`translator.py:1777` and ~8 sibling provider branches), which is why this surfaced as a bare `Client error '400 Bad Request'` with no reason. Logging `resp.text` on 4xx would make provider failures self-diagnosing, but it touches every provider branch and is a separate concern from this bug — happy to send it as a follow-up PR if you want it.
